### PR TITLE
Fix for new sample naming spec

### DIFF
--- a/src/update_runfolders.sh
+++ b/src/update_runfolders.sh
@@ -8,12 +8,12 @@ main() {
     echo "Value of SampleSheet: '$SampleSheet'"
 
     dx download "$SampleSheet" -o SampleSheet
-    
-    project_name=$(dx describe $DX_PROJECT_CONTEXT_ID | grep ^Name | awk -F " " '{print $NF}')
+
+    project_name=$(dx describe --name $DX_PROJECT_CONTEXT_ID)
     IFS='\_' read -r category runfolder <<< $project_name # Remove project prefix e.g. 002
     echo "RF $runfolder"
-    samples=$(sed "0,/Data/d" < SampleSheet | sed '1d' | awk -F "," '{print $2}' | grep -v NA12878 | sort | uniq )  # Get all sample IDs, except NA12878 (as it's not in the database)
-    
+    samples=$(sed "0,/Data/d" < SampleSheet | sed '1d' | awk -F "," '{print $2}' | awk -F "-" '{print $1}' | grep -v NA12878 | sort | uniq )  # Get all sample IDs, except NA12878 (as it's not in the database)
+
     for sample in $samples; do
         echo "${sample}^${runfolder}";
     done > linux_update_runfolders.txt


### PR DESCRIPTION
Now splits sampleID field on '-' to get correct sub-field. 
Made dx describe command cleaner. 
Cleaned up whitespace

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_update_runfolders/10)
<!-- Reviewable:end -->
